### PR TITLE
Number of SQL queries in pricing table opitmized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ venv
 
 #sqlite
 *.sqlite
+
+#Mac
+.DS_Store

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -31,7 +31,7 @@ Optionally create virtual environment and get required packages to run example p
 .. code-block:: bash
 
     $ cd django-plans
-    $ pip install -r /demo/requirements.txt
+    $ pip install -r demo/requirements.txt
     $ pip install -e .
 
 

--- a/plans/views.py
+++ b/plans/views.py
@@ -113,7 +113,10 @@ class PlanTableViewBase(PlanTableMixin, ListView):
 
         if self.request.user.is_authenticated():
             try:
-                self.userplan = UserPlan.objects.select_related('plan').get(user=self.request.user)
+                self.userplan = UserPlan.objects.prefetch_related(
+                    'plan__planpricing_set__pricing',
+                    'plan__planquota_set__quota'
+                ).get(user=self.request.user)
             except UserPlan.DoesNotExist:
                 self.userplan = None
 


### PR DESCRIPTION
Opening pricing view created 22 queries and this number grew with every new Plan, because of Plan.is_free() function.
Now there are 15 queries and they are independent of number of Plans.
piggyback:
- updated gitignore
- removed typo from docs